### PR TITLE
New method to set shape of model inputs

### DIFF
--- a/models_generation/distilbert.py
+++ b/models_generation/distilbert.py
@@ -6,6 +6,14 @@ model = TFDistilBertForQuestionAnswering.from_pretrained('distilbert-base-uncase
 input_spec = tf.TensorSpec([1, 384], tf.int32)
 model._set_inputs(input_spec, training=False)
 
+
+# For tensorflow>2.2.0, set inputs in the following way.
+# Otherwise, the model.inputs and model.outputs will be None.
+# keras_input = tf.keras.Input([384], batch_size=1, dtype=tf.int32)
+# keras_output = model(keras_input, training=False)
+# model = tf.keras.Model(keras_input, keras_output)
+
+
 print(model.inputs)
 print(model.outputs)
 

--- a/models_generation/gpt2.py
+++ b/models_generation/gpt2.py
@@ -6,6 +6,12 @@ model = TFGPT2LMHeadModel.from_pretrained('gpt2') # or 'distilgpt2'
 input_spec = tf.TensorSpec([1, 64], tf.int32)
 model._set_inputs(input_spec, training=False)
 
+# For tensorflow>2.2.0, set inputs in the following way.
+# Otherwise, the model.inputs and model.outputs will be None.
+# keras_input = tf.keras.Input([64], batch_size=1, dtype=tf.int32)
+# keras_output = model(keras_input, training=False)
+# model = tf.keras.Model(keras_input, keras_output)
+
 print(model.inputs)
 print(model.outputs)
 


### PR DESCRIPTION
For tensorflow>=2.2.0, the model._set_inputs failed in https://github.com/huggingface/tflite-android-transformers/blob/dcd6da1bfb28e3cd6bc83b58a112cdcd3d6cc2fe/models_generation/gpt2.py#L7 , and the model.inputs and model.outpus are all None.
The following error will happen when running in Android:
```java.lang.IllegalStateException: Internal error: Unexpected failure when preparing tensor allocations: tensorflow/lite/kernels/kernel_util.cc:249 d1 == d2 || d1 == 1 || d2 == 1 was not true.```
For tensorflow<=2.1.0, the error will not happen.

The added code set inputs shape of model by adding an additional layer, and it works for both tensorflow>=2.2 and tensorflow<2.2
